### PR TITLE
Added support for Twig 2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
 		"php": ">=5.5.0",
-        "twig/twig": "~1.12"
+        "twig/twig": "~1.12 | ~2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Hola Jose,

We're are using your great library, and still very happy with it.

However recently we're starting upgrading projects to PHP 7.1 and Symfony 3, and I found that your library blocks upgrade of Twig to version 2. This PR is a fix for it. Would you be able to merge it please?

Thank you!