### PR TITLE
Symfony 3 support and correctly allow Twig 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: php
 php:
+  - "7.1"
   - "7.0"
   - "5.6"
   - "5.5"
 install:
   - composer selfupdate
   - composer install
-script: 
+script:
   - ./vendor/phpunit/phpunit/phpunit
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Time ago in words Twig extension
 [![Packagist](https://img.shields.io/packagist/dt/salavert/time-ago-in-words.svg)]() [![Build Status](https://travis-ci.org/salavert/time-ago-in-words.svg?branch=master)](https://travis-ci.org/salavert/time-ago-in-words)
 
-This is a Twig extension for Symfony2 Framework where you can easily convert a datetime/timestamp to a distance of time in words.
+This is a Twig extension for Symfony Framework where you can easily convert a datetime/timestamp to a distance of time in words.
 
 By example
 
@@ -11,7 +11,7 @@ By example
 
 Outputs __3 days ago__
 
-# Installation for Symfony2
+# Installation for Symfony
 
 1) Update your composer.json
 

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     ],
     "require": {
 		"php": ">=5.5.0",
-        "twig/twig": "~1.12 | ~2"
+        "twig/twig": "~1.12 || ~2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/symfony": "2.*"
+        "symfony/symfony": "2.* || 3.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
The composer.json wasn't configured correctly to allow Twig 2.*. This was done with a single `|` but should be done with 2 `||`. ([docs](https://getcomposer.org/doc/articles/versions.md#version-range)).

Also incorporated #24. So now this bundle will be up to date and available for SF3+Twig2.