### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: php
 php:
+  - "7.3"
+  - "7.2"
   - "7.1"
-  - "7.0"
-  - "5.6"
-  - "5.5"
 install:
   - composer selfupdate
   - composer install
 script:
-  - ./vendor/phpunit/phpunit/phpunit
-
+  - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,22 @@
         }
     ],
     "require": {
-		"php": ">=5.5.0",
+        "php": "^7.1",
         "twig/twig": "~1.12 || ~2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "^7.0",
         "symfony/symfony": "2.* || 3.*"
     },
     "autoload": {
-        "psr-0": {
-			"Salavert": "src/",
-			"Salavert\\Test": "tests/"
+        "psr-4": {
+			"Salavert\\Twig\\Extension\\": "src/Salavert/Twig/Extension/"
 		}
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Salavert\\Tests\\": "tests/"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,7 @@
 
     <filter>
         <whitelist>
-            <directory>./</directory>
+            <directory>./src/</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Salavert/Twig/Extension/TimeAgoExtension.php
+++ b/src/Salavert/Twig/Extension/TimeAgoExtension.php
@@ -28,10 +28,10 @@ class TimeAgoExtension extends \Twig_Extension
      */
     public function getFilters()
     {
-        return array(
-            new \Twig_SimpleFilter('distance_of_time_in_words', array($this, 'distanceOfTimeInWordsFilter')),
-            new \Twig_SimpleFilter('time_ago_in_words', array($this, 'timeAgoInWordsFilter')),
-        );
+        return [
+            new \Twig_SimpleFilter('distance_of_time_in_words', [$this, 'distanceOfTimeInWordsFilter']),
+            new \Twig_SimpleFilter('time_ago_in_words', [$this, 'timeAgoInWordsFilter']),
+        ];
     }
 
     /**
@@ -107,13 +107,13 @@ class TimeAgoExtension extends \Twig_Extension
         if ($distance_in_minutes <= 1) {
             if ($include_seconds) {
                 if ($distance_in_seconds < 5) {
-                    return $this->translator->trans('less than %seconds seconds ago', array('%seconds' => 5));
+                    return $this->translator->trans('less than %seconds seconds ago', ['%seconds' => 5]);
                 }
                 if ($distance_in_seconds < 10) {
-                    return $this->translator->trans('less than %seconds seconds ago', array('%seconds' => 10));
+                    return $this->translator->trans('less than %seconds seconds ago', ['%seconds' => 10]);
                 }
                 if ($distance_in_seconds < 20) {
-                    return $this->translator->trans('less than %seconds seconds ago', array('%seconds' => 20));
+                    return $this->translator->trans('less than %seconds seconds ago', ['%seconds' => 20]);
                 }
                 if ($distance_in_seconds < 40) {
                     return $this->translator->trans('half a minute ago');
@@ -132,7 +132,7 @@ class TimeAgoExtension extends \Twig_Extension
         }
 
         if ($distance_in_minutes <= 45) {
-            return $this->translator->trans('%minutes minutes ago', array('%minutes' => $distance_in_minutes));
+            return $this->translator->trans('%minutes minutes ago', ['%minutes' => $distance_in_minutes]);
         }
 
         if ($distance_in_minutes <= 90) {
@@ -142,7 +142,7 @@ class TimeAgoExtension extends \Twig_Extension
         if ($distance_in_minutes <= 1440) {
             return $this->translator->trans(
                 'about %hours hours ago',
-                array('%hours' => round($distance_in_minutes/60))
+                ['%hours' => round($distance_in_minutes/60)]
             );
         }
 
@@ -153,21 +153,21 @@ class TimeAgoExtension extends \Twig_Extension
         $distance_in_days = round($distance_in_minutes/1440);
 
         if (!$include_months || $distance_in_days <= 30) {
-            return $this->translator->trans('%days days ago', array('%days' => round($distance_in_days)));
+            return $this->translator->trans('%days days ago', ['%days' => round($distance_in_days)]);
         }
 
         if ($distance_in_days < 345) {
             return $this->translator->transchoice(
                 '{1} 1 month ago |]1,Inf[ %months months ago',
                 round($distance_in_days/30),
-                array('%months' => round($distance_in_days/30))
+                ['%months' => round($distance_in_days/30)]
             );
         }
 
         return $this->translator->transchoice(
             '{1} 1 year ago |]1,Inf[ %years years ago',
             round($distance_in_days/365),
-            array('%years' => round($distance_in_days/365))
+            ['%years' => round($distance_in_days/365)]
         );
     }
 
@@ -183,15 +183,15 @@ class TimeAgoExtension extends \Twig_Extension
         if ($distance_in_minutes <= 1) {
             if ($include_seconds) {
                 if ($distance_in_seconds < 5) {
-                    return $this->translator->trans('in less than %seconds seconds', array('%seconds' => 5));
+                    return $this->translator->trans('in less than %seconds seconds', ['%seconds' => 5]);
                 }
 
                 if ($distance_in_seconds < 10) {
-                    return $this->translator->trans('in less than %seconds seconds', array('%seconds' => 10));
+                    return $this->translator->trans('in less than %seconds seconds', ['%seconds' => 10]);
                 }
 
                 if ($distance_in_seconds < 20) {
-                    return $this->translator->trans('in less than %seconds seconds', array('%seconds' => 20));
+                    return $this->translator->trans('in less than %seconds seconds', ['%seconds' => 20]);
                 }
 
                 if ($distance_in_seconds < 40) {
@@ -212,7 +212,7 @@ class TimeAgoExtension extends \Twig_Extension
         }
 
         if ($distance_in_minutes <= 45) {
-            return $this->translator->trans('in %minutes minutes', array('%minutes' => $distance_in_minutes));
+            return $this->translator->trans('in %minutes minutes', ['%minutes' => $distance_in_minutes]);
         }
 
         if ($distance_in_minutes <= 90) {
@@ -220,14 +220,14 @@ class TimeAgoExtension extends \Twig_Extension
         }
 
         if ($distance_in_minutes <= 1440) {
-            return $this->translator->trans('in about %hours hours', array('%hours' => round($distance_in_minutes/60)));
+            return $this->translator->trans('in about %hours hours', ['%hours' => round($distance_in_minutes/60)]);
         }
 
         if ($distance_in_minutes <= 2880) {
             return $this->translator->trans('in 1 day');
         }
 
-        return $this->translator->trans('in %days days', array('%days' => round($distance_in_minutes/1440)));
+        return $this->translator->trans('in %days days', ['%days' => round($distance_in_minutes/1440)]);
     }
 
     /**

--- a/tests/TranslationsTest.php
+++ b/tests/TranslationsTest.php
@@ -4,10 +4,13 @@ namespace Salavert\Tests;
 
 date_default_timezone_set('Europe/Madrid');
 
+use Twig_SimpleFilter;
 use Salavert\Twig\Extension\TimeAgoExtension;
 use Symfony\Component\Translation\IdentityTranslator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\DateTime;
 
-class TranslationsTest extends \PHPUnit_Framework_TestCase
+class TranslationsTest extends TestCase
 {
     const DEFAULT_INCLUDE_SECONDS = false;
     const DEFAULT_INCLUDE_MONTHS = false;
@@ -20,11 +23,26 @@ class TranslationsTest extends \PHPUnit_Framework_TestCase
     /** @var TimeAgoExtension */
     private $extension;
 
-    public function setUp() {
+    protected function setUp()
+    {
         $this->extension = new TimeAgoExtension(new IdentityTranslator);
     }
 
-    public function testExtensionName() {
+    public function testGetFilters()
+    {
+        $filters = $this->extension->getFilters();
+
+        $this->assertCount(2, $filters);
+        $this->assertInstanceOf(Twig_SimpleFilter::class, $filters[0]);
+        $this->assertInstanceOf(Twig_SimpleFilter::class, $filters[1]);
+    }
+
+    public function testTimeAgoInWordsFilter()
+    {
+        $this->assertContains('days ago', $this->extension->timeAgoInWordsFilter('2017-04-04 00:00:00'));
+    }
+    public function testExtensionName()
+    {
         $this->assertEquals("time_ago_extension", $this->extension->getName());
     }
 
@@ -124,90 +142,90 @@ class TranslationsTest extends \PHPUnit_Framework_TestCase
 
     public function dataFromSecondsToOneMinuteWithIncludeSeconds()
     {
-        return array(
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:04", "less than 5 seconds ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:05", "less than 10 seconds ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:09", "less than 10 seconds ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:10", "less than 20 seconds ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:20", "half a minute ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:39", "half a minute ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:40", "less than a minute ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:59", "less than a minute ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:01:00", "1 minute ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:01:29", "1 minute ago"),
-        );
+        return [
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:04", "less than 5 seconds ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:05", "less than 10 seconds ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:09", "less than 10 seconds ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:10", "less than 20 seconds ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:20", "half a minute ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:39", "half a minute ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:40", "less than a minute ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:59", "less than a minute ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:01:00", "1 minute ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:01:29", "1 minute ago"],
+        ];
     }
 
     public function dataFromSecondsToOneMinuteWithoutIncludeSeconds()
     {
-        return array(
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:01", "less than a minute ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:29", "less than a minute ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:00:30", "1 minute ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:01:29", "1 minute ago"),
-        );
+        return [
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:01", "less than a minute ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:29", "less than a minute ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:00:30", "1 minute ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:01:29", "1 minute ago"],
+        ];
     }
 
     public function dataFromMinutesToAboutOneHour()
     {
-        return array(
-            array("2015-07-01 00:00:00", "2015-07-01 00:01:30", "2 minutes ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:02:29", "2 minutes ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:45:29", "45 minutes ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 00:45:30", "about 1 hour ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 01:30:29", "about 1 hour ago"),
-        );
+        return [
+            ["2015-07-01 00:00:00", "2015-07-01 00:01:30", "2 minutes ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:02:29", "2 minutes ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:45:29", "45 minutes ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 00:45:30", "about 1 hour ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 01:30:29", "about 1 hour ago"],
+        ];
     }
 
     public function dataFromHoursToOneDay()
     {
-        return array(
-            array("2015-07-01 00:00:00", "2015-07-01 01:30:30", "about 2 hours ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 02:00:29", "about 2 hours ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 02:30:30", "about 3 hours ago"),
-            array("2015-07-01 00:00:00", "2015-07-01 23:30:29", "about 24 hours ago"),
-            array("2015-07-01 00:00:00", "2015-07-02 00:00:29", "about 24 hours ago"),
-            array("2015-07-01 00:00:00", "2015-07-02 00:00:30", "1 day ago"),
-        );
+        return [
+            ["2015-07-01 00:00:00", "2015-07-01 01:30:30", "about 2 hours ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 02:00:29", "about 2 hours ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 02:30:30", "about 3 hours ago"],
+            ["2015-07-01 00:00:00", "2015-07-01 23:30:29", "about 24 hours ago"],
+            ["2015-07-01 00:00:00", "2015-07-02 00:00:29", "about 24 hours ago"],
+            ["2015-07-01 00:00:00", "2015-07-02 00:00:30", "1 day ago"],
+        ];
     }
 
     public function dataFromDaysToOneYearWithoutIncludeMonths()
     {
-        return array(
-            array("2015-07-01 00:00:00", "2015-07-03 00:00:29", "1 day ago"),
-            array("2015-07-01 00:00:00", "2015-07-03 00:00:30", "2 days ago"),
-            array("2015-07-01 00:00:00", "2015-07-16 00:00:29", "15 days ago"),
-            array("2015-07-01 00:00:00", "2015-07-31 00:00:29", "30 days ago"),
-            array("2015-07-01 00:00:00", "2015-08-01 00:00:00", "31 days ago"),
+        return [
+            ["2015-07-01 00:00:00", "2015-07-03 00:00:29", "1 day ago"],
+            ["2015-07-01 00:00:00", "2015-07-03 00:00:30", "2 days ago"],
+            ["2015-07-01 00:00:00", "2015-07-16 00:00:29", "15 days ago"],
+            ["2015-07-01 00:00:00", "2015-07-31 00:00:29", "30 days ago"],
+            ["2015-07-01 00:00:00", "2015-08-01 00:00:00", "31 days ago"],
             # Switching from month 11 to 12
-            array("2015-07-01 00:00:00", "2016-6-09 11:59:29", "344 days ago"),
-            array("2015-07-01 00:00:00", "2016-6-09 11:59:30", "345 days ago"),
+            ["2015-07-01 00:00:00", "2016-6-09 11:59:29", "344 days ago"],
+            ["2015-07-01 00:00:00", "2016-6-09 11:59:30", "345 days ago"],
             # Reaching a full year
-            array("2015-07-01 00:00:00", "2016-6-29 11:59:29", "364 days ago"),
-            array("2015-07-01 00:00:00", "2016-6-29 11:59:30", "365 days ago"),
+            ["2015-07-01 00:00:00", "2016-6-29 11:59:29", "364 days ago"],
+            ["2015-07-01 00:00:00", "2016-6-29 11:59:30", "365 days ago"],
             # Exceeding a year by a month or so
-            array("2015-07-01 00:00:00", "2016-8-04 00:00:00", "400 days ago"),
-        );
+            ["2015-07-01 00:00:00", "2016-8-04 00:00:00", "400 days ago"],
+        ];
     }
 
     public function dataFromDaysToOneYearWithIncludeMonths()
     {
-        return array(
-            array("2015-07-01 00:00:00", "2015-07-03 00:00:29", "1 day ago"),
-            array("2015-07-01 00:00:00", "2015-07-03 00:00:30", "2 days ago"),
-            array("2015-07-01 00:00:00", "2015-07-16 00:00:29", "15 days ago"),
-            array("2015-07-01 00:00:00", "2015-07-31 00:00:29", "30 days ago"),
-            array("2015-07-01 00:00:00", "2015-08-01 00:00:00", "1 month ago"),
+        return [
+            ["2015-07-01 00:00:00", "2015-07-03 00:00:29", "1 day ago"],
+            ["2015-07-01 00:00:00", "2015-07-03 00:00:30", "2 days ago"],
+            ["2015-07-01 00:00:00", "2015-07-16 00:00:29", "15 days ago"],
+            ["2015-07-01 00:00:00", "2015-07-31 00:00:29", "30 days ago"],
+            ["2015-07-01 00:00:00", "2015-08-01 00:00:00", "1 month ago"],
             # Switching from month 11 to 12
-            array("2015-07-01 00:00:00", "2016-6-09 11:59:29", "11 months ago"),
-            array("2015-07-01 00:00:00", "2016-6-09 11:59:30", "1 year ago"), # Instead of 12 months ago
+            ["2015-07-01 00:00:00", "2016-6-09 11:59:29", "11 months ago"],
+            ["2015-07-01 00:00:00", "2016-6-09 11:59:30", "1 year ago"], # Instead of 12 months ago
             # Reaching a full year
-            array("2015-07-01 00:00:00", "2016-6-29 11:59:29", "1 year ago"), # Instead of 12 months ago
+            ["2015-07-01 00:00:00", "2016-6-29 11:59:29", "1 year ago"], # Instead of 12 months ago
             # Exact moment we round distance of time and reach 365 days
-            array("2015-07-01 00:00:00", "2016-6-29 11:59:30", "1 year ago"),
+            ["2015-07-01 00:00:00", "2016-6-29 11:59:30", "1 year ago"],
             # 400 days
-            array("2015-07-01 00:00:00", "2016-8-04 00:00:00", "1 year ago"),
-            array("2015-07-01 00:00:00", "2018-8-04 00:00:00", "3 years ago"),
-        );
+            ["2015-07-01 00:00:00", "2016-8-04 00:00:00", "1 year ago"],
+            ["2015-07-01 00:00:00", "2018-8-04 00:00:00", "3 years ago"],
+        ];
     }
 }


### PR DESCRIPTION
# Changed log
- Drop `php-5.x` supports because they're deprecated now.
- The `composer.json` file is under the `\r\n` for the new line, and using the `\n` instead.
- Add some missed method tests for this class.
- Add the current white filter list in `phpunit.xml.dist` setting.
- Using the short array syntax and this feature is available since `php-5.4` version.