### PR TITLE
Add explicit dependency on symfony/form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1",
         "twig/twig": "~1.12 || ~2",
-	"symfony/form": "2.* || 3.* || 4.*"
+        "symfony/form": "2.* || 3.* || 4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": "^7.1",
-        "twig/twig": "~1.12 || ~2"
+        "twig/twig": "~1.12 || ~2",
+	"symfony/form": "2.* || 3.* || 4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
Just a suggestion: this package depends on the DateTimeToStringTransformer from symfony/form